### PR TITLE
Initial attempt at creating a reaction with the HTTP function.

### DIFF
--- a/.atomist/handlers/GitHubApi.ts
+++ b/.atomist/handlers/GitHubApi.ts
@@ -1,0 +1,68 @@
+export class Repository {
+    constructor(readonly owner: string, readonly name: string) {}
+    readonly url = `/repos/${this.owner}/${this.name}/`;
+    issue(number: number): Issue {
+        return new Issue(this, number)
+    }
+    issueComment(id: number): IssueComment {
+        return new IssueComment(this, id)
+    }
+}
+
+export abstract class Reactable {
+    readonly url: string;
+    readonly reactionsUrl = `${this.url}reactions`;
+    readonly reactionHeader = {
+        "Accept": "application/vnd.github.squirrel-girl-preview"
+    }
+
+    react(reaction: Reaction): Http {
+        return {
+            "url": `${this.url}reactions`,
+            "method": "POST",
+            "config": {
+                "body": reaction,
+                "headers": this.reactionHeader
+            }
+        }
+    }
+
+    reactions(): Http {
+        return {
+            "url": `${this.url}reactions`,
+            "method": "GET",
+            "config": {
+                "headers": this.reactionHeader
+            }
+        }
+    }
+}
+
+export class Issue extends Reactable {
+    constructor(readonly repo: Repository, readonly number: number) { super() }
+    readonly url = `${this.repo.url}issues/${this.number}/`;
+}
+
+export class IssueComment extends Reactable {
+    constructor(readonly repo: Repository, readonly id: number) { super() }
+    readonly url = `${this.repo.url}issues/comments/${this.id}/`;
+}
+
+export type ReactionContent = "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray"
+
+export class Reaction {
+    content: ReactionContent
+}
+
+export type HttpMethod = "HEAD" | "GET" | "POST" | "PATCH" | "PUT" | "DELETE"
+
+export class Http {
+    readonly url: string;
+    readonly method: HttpMethod;
+    readonly config?: HttpConfig;
+}
+
+export class HttpConfig {
+    readonly body?: Object;
+    readonly headers?: Object;
+}

--- a/.atomist/manifest.yml
+++ b/.atomist/manifest.yml
@@ -4,3 +4,4 @@ version: "0.25.0"
 requires: "0.24.0"
 extensions:
   - "com.atomist.rug:rug-functions-github:0.14.0"
+  - "com.atomist.rug:rug-function-http:0.2.0"

--- a/.atomist/tests/handlers/command/reaction/ReactIssueTest.feature
+++ b/.atomist/tests/handlers/command/reaction/ReactIssueTest.feature
@@ -3,5 +3,5 @@ Feature: Add reaction to a GitHub issue
   Scenario: Add reaction to a GitHub issue
     When ReactGitHubIssue on issue 1 is invoked with valid input
     Then respond with a single instruction
-    Then execute react-github-issue instruction
+    Then execute http instruction
     Then on success send 'Successfully reacted with :+1: to testOwner/testRepo/issues/#1'

--- a/.atomist/tests/handlers/command/reaction/ReactSteps.ts
+++ b/.atomist/tests/handlers/command/reaction/ReactSteps.ts
@@ -39,6 +39,14 @@ Then("execute ([a-z\\-]+) instruction", (world: HandlerScenarioWorld, expectedIn
     return name == expectedInstructionName
 });
 
+Then("execute http instruction", (world: HandlerScenarioWorld) => {
+    const w: CommandHandlerScenarioWorld = world as CommandHandlerScenarioWorld;
+    const respondable = w.plan().instructions[0] as Respondable<Execute>;
+    const instruction = respondable.instruction as Execute;
+    const http = instruction.parameters;
+    return instruction.name == "http" && http["method"] == "POST" && http["url"] == "/repos/testOwner/testRepo/issues/1/reactions"
+});
+
 Then("on success send '(.+)'", (world: HandlerScenarioWorld, expectedSuccessMessage: string) => {
     let w: CommandHandlerScenarioWorld = world as CommandHandlerScenarioWorld;
     const respondable = w.plan().instructions[0] as Respondable<Execute>;

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 **/*.js
 .idea
 *.iml
+.vscode


### PR DESCRIPTION
This should work but I get an error importing '../../GithubApi' from ReactIssues.ts.
I think this should work because both vs code and tsc have no problem with it. The “rug test” command gives the following error:

$ rug test
Resolving dependencies for atomist-rugs:github-handlers (0.25.0·local) completed
Invoking TypeScript Compiler on .ts files
Invoking compilers on project sources failed

.atomist/handlers/command/reaction/ReactIssue.ts(4,43): error TS2307: Cannot find module '../../GithubApi'.
import {Repository, ReactionContent} from '../../GithubApi'